### PR TITLE
Support X and Twitter redirects

### DIFF
--- a/fastside/src/routes/redirect.rs
+++ b/fastside/src/routes/redirect.rs
@@ -127,7 +127,7 @@ pub async fn find_redirect(
     let is_url_query = if path.starts_with("http://") || path.starts_with("https://") {
         true
     } else {
-        path[0..path.find('/').unwrap_or(0)].contains('.')
+        path.split('/').next().unwrap_or_default().contains('.')
     };
 
     let guard = crawler.read().await;

--- a/services.json
+++ b/services.json
@@ -3263,7 +3263,16 @@
       "follow_redirects": false,
       "allowed_http_codes": "200",
       "search_string": null,
-      "regexes": [],
+      "regexes": [
+        {
+          "regex": "^(https?:\\/\\/)?((www\\.|mobile\\.)?twitter\\.com)(\\/.*|)$",
+          "url": "$4"
+        },
+        {
+          "regex": "^(https?:\\/\\/)?((www\\.)?x\\.com)(\\/.*|)$",
+          "url": "$4"
+        }
+      ],
       "aliases": [],
       "source_link": null,
       "deprecated_message": "Discontinued. Twitter has blocked all instances.",


### PR DESCRIPTION
Add Nitter URL matchers for x.com and twitter.com. Fixes #43.