### PR TITLE
Add Shitter instances and deprecate Nitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Contents
 A redirecting service for FOSS alternative frontends.
 
 [Fastside](https://fastsi.de/) provides links that automatically redirect to
-working instances of privacy-oriented alternative frontends, such as Nitter,
+working instances of privacy-oriented alternative frontends, such as Shitter,
 Libreddit, etc. This allows for users to have more reliable access to the
 available public instances for a particular service, while also helping to
 distribute traffic more evenly across all instances and avoid performance

--- a/fastside-actualizer/src/services/libredirect.rs
+++ b/fastside-actualizer/src/services/libredirect.rs
@@ -13,7 +13,6 @@ pub const LIBREDIRECT_SERVICES: &[&str] = &[
     "cloudtube",
     "proxitok",
     "send",
-    "nitter",
     "redlib",
     "scribe",
     "quetre",

--- a/fastside-actualizer/src/services/mod.rs
+++ b/fastside-actualizer/src/services/mod.rs
@@ -12,6 +12,7 @@ mod librex;
 mod scribe;
 mod searx;
 mod searxng;
+mod shitter;
 mod simplytranslate;
 mod soprano;
 mod tent;
@@ -24,6 +25,7 @@ pub use default::DefaultInstanceChecker;
 /// Get a service updater by name.
 pub fn get_service_updater(name: &str) -> Option<Box<dyn ServiceUpdater>> {
     match name {
+        "shitter" => Some(Box::new(shitter::ShitterUpdater::new())),
         "searx" => Some(Box::new(searx::SearxUpdater::new())),
         "searxng" => Some(Box::new(searxng::SearxngUpdater::new())),
         "simplytranslate" => Some(Box::new(simplytranslate::SimplyTranslateUpdater::new())),

--- a/fastside-actualizer/src/services/shitter.rs
+++ b/fastside-actualizer/src/services/shitter.rs
@@ -1,0 +1,165 @@
+use crate::{ChangesSummary, types::ServiceUpdater};
+use async_trait::async_trait;
+use fastside_shared::serde_types::Instance;
+use url::Url;
+
+pub struct ShitterUpdater {
+    pub instances_url: String,
+}
+
+impl ShitterUpdater {
+    pub fn new() -> Self {
+        Self {
+            instances_url: "https://codeberg.org/mv12star/shitter/wiki/raw/Instances".into(),
+        }
+    }
+}
+
+/// Read only working instances. Other sections contain redirectors and dead hosts.
+fn parse_instance_urls(markdown: &str) -> anyhow::Result<Vec<Url>> {
+    let mut working = false;
+    let mut urls = Vec::new();
+    for line in markdown.lines().map(str::trim) {
+        if line.starts_with('#') {
+            working = line.trim_start_matches('#').trim() == "Working instances";
+            continue;
+        }
+        if !working {
+            continue;
+        }
+        let Some(entry) = line.strip_prefix("- ").or_else(|| line.strip_prefix("* ")) else {
+            continue;
+        };
+        // The wiki uses bare URLs, with optional notes such as "(Tor)".
+        let Some(value) = entry.split_whitespace().next() else {
+            continue;
+        };
+        let Ok(url) = Url::parse(value) else {
+            continue;
+        };
+        if matches!(url.scheme(), "http" | "https")
+            && url.host_str().is_some()
+            && !urls.contains(&url)
+        {
+            urls.push(url);
+        }
+    }
+    anyhow::ensure!(
+        !urls.is_empty(),
+        "No working Shitter instances found in the wiki"
+    );
+    Ok(urls)
+}
+
+#[async_trait]
+impl ServiceUpdater for ShitterUpdater {
+    async fn update(
+        &self,
+        client: reqwest::Client,
+        current_instances: &[Instance],
+        changes_summary: ChangesSummary,
+    ) -> anyhow::Result<Vec<Instance>> {
+        let response = client
+            .get(&self.instances_url)
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        let urls = parse_instance_urls(&response)?;
+        let mut instances = current_instances.to_vec();
+        let mut added = Vec::new();
+        for url in urls {
+            if instances.iter().any(|instance| instance.url == url) {
+                continue;
+            }
+            added.push(url.clone());
+            instances.push(Instance::from(url));
+        }
+        changes_summary
+            .set_new_instances_added("shitter", added)
+            .await;
+        Ok(instances)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovers_only_working_instances() {
+        let urls = parse_instance_urls(
+            "# Working instances\r\n\
+             - https://shitter.example\r\n\
+             - https://shitter.example/\r\n\
+             - http://example.onion (requires Tor browser)\r\n\
+             - invalid\r\n\
+             - ftp://files.example\r\n\
+             ### Redirectors\r\n\
+             - https://redirect.example\r\n\
+             ### Active but rate limited\r\n\
+             - https://limited.example\r\n\
+             ### Formerly active / Taken down\r\n\
+             - https://dead.example\r\n\
+             # Run a public instance\r\n\
+             - https://docs.example\r\n",
+        )
+        .unwrap();
+        assert_eq!(
+            urls,
+            vec![
+                Url::parse("https://shitter.example/").unwrap(),
+                Url::parse("http://example.onion/").unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_working_list() {
+        for input in [
+            "<html>Access denied</html>",
+            "# Working instances\n",
+            "# Redirectors\n- https://redirect.example",
+        ] {
+            assert!(parse_instance_urls(input).is_err());
+        }
+    }
+
+    #[test]
+    fn catalogue_replaces_nitter() {
+        let data: fastside_shared::serde_types::StoredData =
+            serde_json::from_str(include_str!("../../../services.json")).unwrap();
+        let shitter = data.services.iter().find(|s| s.name == "shitter").unwrap();
+        let nitter = data.services.iter().find(|s| s.name == "nitter").unwrap();
+        assert!(shitter.deprecated_message.is_none());
+        assert!(!shitter.instances.is_empty());
+        assert!(
+            nitter
+                .deprecated_message
+                .as_ref()
+                .unwrap()
+                .contains("Shitter")
+        );
+        assert!(nitter.instances.is_empty());
+        assert!(nitter.regexes.is_empty());
+        for url in [
+            "https://twitter.com/jack/status/20",
+            "https://x.com/jack/status/20",
+        ] {
+            let matches: Vec<_> = data
+                .services
+                .iter()
+                .filter(|s| {
+                    s.regexes
+                        .iter()
+                        .any(|r| regex::Regex::new(&r.regex).unwrap().is_match(url))
+                })
+                .map(|s| s.name.as_str())
+                .collect();
+            assert_eq!(matches, vec!["shitter"]);
+        }
+        assert!(super::super::get_service_updater("shitter").is_some());
+        assert!(super::super::get_service_updater("nitter").is_none());
+    }
+}

--- a/services.json
+++ b/services.json
@@ -3330,114 +3330,11 @@
       "follow_redirects": false,
       "allowed_http_codes": "200",
       "search_string": null,
-      "regexes": [
-        {
-          "regex": "^(https?:\\/\\/)?((www\\.|mobile\\.)?twitter\\.com)(\\/.*|)$",
-          "url": "$4"
-        },
-        {
-          "regex": "^(https?:\\/\\/)?((www\\.)?x\\.com)(\\/.*|)$",
-          "url": "$4"
-        }
-      ],
+      "regexes": [],
       "aliases": [],
       "source_link": null,
-      "deprecated_message": "Discontinued. Twitter has blocked all instances.",
-      "instances": [
-        {
-          "url": "http://nitter.catsarchywsyuss6jdxlypsw5dc7owd5u5tr6bujxb7o6xw2hipqehyd.onion/",
-          "tags": [
-            "http",
-            "tor"
-          ]
-        },
-        {
-          "url": "https://lightbrd.com/",
-          "tags": [
-            "antibot",
-            "clearnet",
-            "cloudflare",
-            "https",
-            "ipv4",
-            "ipv6"
-          ]
-        },
-        {
-          "url": "https://nitter.catsarch.com/",
-          "tags": [
-            "clearnet",
-            "https",
-            "ipv4",
-            "ipv6"
-          ]
-        },
-        {
-          "url": "https://nitter.kareem.one/",
-          "tags": [
-            "antibot",
-            "clearnet",
-            "cloudflare",
-            "https",
-            "ipv4",
-            "ipv6"
-          ]
-        },
-        {
-          "url": "https://nitter.poast.org/",
-          "tags": [
-            "clearnet",
-            "https"
-          ]
-        },
-        {
-          "url": "https://nitter.privacyredirect.com/",
-          "tags": [
-            "clearnet",
-            "https",
-            "ipv4"
-          ]
-        },
-        {
-          "url": "https://nitter.space/",
-          "tags": [
-            "antibot",
-            "clearnet",
-            "cloudflare",
-            "https",
-            "ipv4",
-            "ipv6"
-          ]
-        },
-        {
-          "url": "https://nitter.tiekoetter.com/",
-          "tags": [
-            "clearnet",
-            "https",
-            "ipv4",
-            "ipv6"
-          ]
-        },
-        {
-          "url": "https://nuku.trabun.org/",
-          "tags": [
-            "antibot",
-            "clearnet",
-            "cloudflare",
-            "https",
-            "ipv4",
-            "ipv6"
-          ]
-        },
-        {
-          "url": "https://xcancel.com/",
-          "tags": [
-            "clearnet",
-            "https",
-            "ipv4",
-            "ipv6"
-          ]
-        }
-      ]
+      "deprecated_message": "Deprecated. Use Shitter instead.",
+      "instances": []
     },
     {
       "type": "osm",
@@ -7168,6 +7065,127 @@
             "https",
             "ipv4",
             "ipv6"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "shitter",
+      "test_url": "/jack/status/20",
+      "fallback": "https://x.com/",
+      "follow_redirects": false,
+      "allowed_http_codes": "200",
+      "search_string": null,
+      "regexes": [
+        {
+          "regex": "^(https?:\\/\\/)?((www\\.|mobile\\.)?twitter\\.com)(\\/.*|)$",
+          "url": "$4"
+        },
+        {
+          "regex": "^(https?:\\/\\/)?((www\\.)?x\\.com)(\\/.*|)$",
+          "url": "$4"
+        }
+      ],
+      "aliases": [],
+      "source_link": "https://codeberg.org/mv12star/shitter",
+      "deprecated_message": null,
+      "instances": [
+        {
+          "url": "http://dhgjnhkxtgesvcddfwzqm4d4zmyz2x2jud6huweu5iywuvoo7qaqpjid.onion/",
+          "tags": [
+            "http",
+            "tor"
+          ]
+        },
+        {
+          "url": "http://nitter.dog5267ah4m4f4677r33b2pzq667lwhsqupojioqz4rg6e2q74p3xtyd.onion/",
+          "tags": [
+            "http",
+            "tor"
+          ]
+        },
+        {
+          "url": "http://nitter.lesboswza6waq3itqo46rvf5a7dibxih32f2umwg6fpssxj66spmclyd.onion/",
+          "tags": [
+            "http",
+            "tor"
+          ]
+        },
+        {
+          "url": "https://nitter.click/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4",
+            "ipv6"
+          ]
+        },
+        {
+          "url": "https://nitter.jaydenha.uk/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4"
+          ]
+        },
+        {
+          "url": "https://nitter.kareem.one/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4",
+            "ipv6"
+          ]
+        },
+        {
+          "url": "https://nitter.meowing.monster/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4",
+            "ipv6"
+          ]
+        },
+        {
+          "url": "https://nitter.miningtcup.me/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4"
+          ]
+        },
+        {
+          "url": "https://nitter.xitter.cc/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4",
+            "ipv6"
+          ]
+        },
+        {
+          "url": "https://shitter.thepixora.com/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4",
+            "ipv6"
+          ]
+        },
+        {
+          "url": "https://tw.eir-nya.gay/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4"
+          ]
+        },
+        {
+          "url": "https://x.n0g.xyz/",
+          "tags": [
+            "clearnet",
+            "https",
+            "ipv4"
           ]
         }
       ]


### PR DESCRIPTION
Add Shitter instance discovery from the upstream wiki and use the existing availability checks. Move Twitter/X URL matching to Shitter and deprecate Nitter.

Closes #49.
